### PR TITLE
Change outline to none on search input focus

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -121,6 +121,7 @@ input#search:focus,
 input#search:focus ~ i {
   background: #fff;
   color: black;
+  outline: none;
 }
 
 .header-link {


### PR DESCRIPTION
As recommended in the [issue](https://github.com/moinkhanif/apple-clone/issues/2) by the team, a change was made:

- To change the outline to none on focus to search input tag. 